### PR TITLE
Add error navigation after a failed test

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -86,6 +86,11 @@
   "^\\s-*\\(?:\\(?:abstract\\|final\\|private\\|protected\\|public\\|static\\)\\s-+\\)*function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*("
   "Regular expression for a PHP function.")
 
+;; Allow for error navigation after a failed test
+(add-hook 'compilation-mode-hook
+          (lambda ()
+            (interactive)
+            (add-to-list 'compilation-error-regexp-alist '("^\\(.+\\.php\\):\\([0-9]+\\)$" 1 2))))
 
 ;; Commands
 ;; -----------


### PR DESCRIPTION
I just added a hook for compilation mode to add a regexp for PHPUnit failed tests, so now errors can be navigated with `previous-error` (`M-p`) and `next-error` (`M-n`), the cursor is automatically placed in the offending line (the one of the assertion or the exception).

I'm not really sure if this is the place to put that, I have no experience modifying modes, it's just something I found useful.