### PR TITLE
Match valid classname in `php-get-current-class`

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -118,12 +118,10 @@
                            "./"))))))
 
 (defun phpunit-get-current-class (&optional file)
+  "Return the class name of the PHPUnit test for `FILE'."
   (let* ((file (or file (buffer-file-name))))
-    (string-match "[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"
-		  (f-filename file))
-    (match-string 0 (f-filename file))
-    )
-  )
+    (string-match "[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*" (f-filename file))
+    (match-string 0 (f-filename file))))
 
 (defun phpunit-get-current-test ()
   (save-excursion

--- a/phpunit.el
+++ b/phpunit.el
@@ -118,10 +118,12 @@
                            "./"))))))
 
 (defun phpunit-get-current-class (&optional file)
-  "Return the class name of the PHPUnit test for `FILE'."
   (let* ((file (or file (buffer-file-name))))
-    (f-filename (replace-regexp-in-string "\\.php\\'" "" file))))
-
+    (string-match "[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"
+		  (f-filename file))
+    (match-string 0 (f-filename file))
+    )
+  )
 
 (defun phpunit-get-current-test ()
   (save-excursion


### PR DESCRIPTION
`php-get-current-class` currently matches the name of a class by dropping any `*.php` suffix from the specified file or the current buffer name.  This only works if the full suffix of the file is limited to `*.php`, unnecessarily enforcing an unstated convention.

A better method of determining the name of the current class would be to seek a valid PHP class name in the filename.  This would obviate any consideration of suffixing practices.