### PR TITLE
More exact filtering

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -81,10 +81,13 @@
   :type 'string
   :group 'phpunit)
 
-
 (defconst php-beginning-of-defun-regexp
   "^\\s-*\\(?:\\(?:abstract\\|final\\|private\\|protected\\|public\\|static\\)\\s-+\\)*function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*("
   "Regular expression for a PHP function.")
+
+(defconst php-label-regexp
+  "[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"
+  "Valid syntax for a PHP label.")
 
 ;; Allow for error navigation after a failed test
 (add-hook 'compilation-mode-hook
@@ -120,7 +123,7 @@
 (defun phpunit-get-current-class (&optional file)
   "Return the class name of the PHPUnit test for `FILE'."
   (let* ((file (or file (buffer-file-name))))
-    (string-match "[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*" (f-filename file))
+    (string-match php-label-regexp (f-filename file))
     (match-string 0 (f-filename file))))
 
 (defun phpunit-get-current-test ()

--- a/phpunit.el
+++ b/phpunit.el
@@ -128,7 +128,7 @@
   "Return the class name of the PHPUnit test for `FILE'."
   (let* (
 	 ;; Normally, find classname by pattern matching backwards.
-	 (classname (save-excursion (re-search-backward php-beginning-of-class)
+	 (classname (save-excursion (re-search-backward php-beginning-of-class 0 t)
 				    (match-string 1)))
 	 ;; The 'file' parameter overrides this.
 	 ;; Fall back to the buffer filename if nothing else works.

--- a/test/phpunit-test.el
+++ b/test/phpunit-test.el
@@ -34,10 +34,19 @@
   (apply 's-concat "phpunit -c " "phpunit.xml" arg))
 
 
-(ert-deftest test-phpunit-get-current-class ()
+(ert-deftest test-phpunit-get-class-from-file-path()
   (should (string= "PhpUnitTest"
-		   (phpunit-get-current-class "/tmp/foo/PhpUnitTest.php")))
-  )
+		   (phpunit-get-current-class "/tmp/foo/PhpUnit.class.under.test.php"))))
+
+(ert-deftest test-phpunit-get-class-from-source-class()
+  (should (string= "PhpUnitTest"
+		   (phpunit-get-current-class "PhpUnit"))))
+
+(ert-deftest test-phpunit-get-class-from-unit-test-class()
+  (should (string= "PhpUnitTest"
+		   (phpunit-get-current-class "PhpUnitTest"))))
+
+
 
 ;; Arguments
 

--- a/test/phpunit-test.el
+++ b/test/phpunit-test.el
@@ -36,7 +36,8 @@
 
 (ert-deftest test-phpunit-get-current-class ()
   (should (string= "PhpUnitTest"
-		   (phpunit-get-current-class "/tmp/foo/PhpUnitTest.php"))))
+		   (phpunit-get-current-class "/tmp/foo/PhpUnitTest.php")))
+  )
 
 ;; Arguments
 


### PR DESCRIPTION
(verbatim from body of commit message:)

This commit is a candidate for merging with the master branch, so a
summary is in order.  Two convenience regexps have been defined as
constants: `php-labelchar-regexp` matches the characters in a valid php
label, and `php-beginning-of-class` seeks the name at the beginning of a
class.  These are used by the rewritten `phpunit-get-current-class` and
`php-current-class` functions.

The `phpunit-get-current-class` function now attempts to identify the
current class from a backwards regexp, but falls back on the buffer name
if that fails.  In either case, it ensures that the final part of the
resulting classname is 'Test', requiring PHPUnit's convention that test
unit classes be named *Class*Test, where 'Class' is the name of the
class under test.

The `phpunit-current-class` function now passes a lookbehind assertion
in the '--filter' option to phpunit.  The purpose of this is to ensure
that no valid php label character can precede the rest of the string
passed to PHPUnit when it is matching against the filter expression.
This, along with enforcing the presence of 'Test' at the end of the
string, should force the isolation of the exact correct unit tests for
any given class.

Unit tests for the revised features of `phpunit-get-current-class` have
been written and included.