### PR TITLE
Fix 'str_repeat...' warning when running tests from Emacs

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -159,9 +159,14 @@
        (setq opts (s-concat opts " --verbose")))
      opts))
 
+(defun phpunit-get-compile-command (args)
+  (let ((column-setting-command (format "stty cols %d" (frame-width)))
+        (command-separator "; ")
+        (phpunit-command (phpunit-get-program (phpunit-arguments args))))
+    (concat column-setting-command command-separator phpunit-command)))
 
 (defun phpunit-run (args)
-  (compile (phpunit-get-program (phpunit-arguments args))))
+  (compile (phpunit-get-compile-command args)))
 
 
 ;; API


### PR DESCRIPTION
I updated PHPUnit from Composer yesterday and found that it triggered an annoying warning when trying to run it from phpunit.el in Emacs.

This was the output:
> PHPUnit 5.0.4 by Sebastian Bergmann and contributors.
> 
> .PHP Warning:  str_repeat(): Second argument has to be greater than or equal to 0 in /*path_to_project*/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php on line 547
> PHP Stack trace:
> PHP   1. {main}() /*path_to_user*/.composer/vendor/phpunit/phpunit/phpunit:0
> PHP   2. PHPUnit_TextUI_Command::main() /*path_to_user*/.composer/vendor/phpunit/phpunit/phpunit:36
> PHP   3. PHPUnit_TextUI_Command->run() /*path_to_user*/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:105
> PHP   4. PHPUnit_TextUI_TestRunner->doRun() /*path_to_user*/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:153
> PHP   5. PHPUnit_Framework_TestSuite->run() /*path_to_project*/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:423
> PHP   6. PHPUnit_Framework_TestSuite->run() /*path_to_project*/vendor/phpunit/phpunit/src/Framework/TestSuite.php:735
> PHP   7. PHPUnit_Framework_TestCase->run() /*path_to_project*/vendor/phpunit/phpunit/src/Framework/TestSuite.php:735
> PHP   8. PHPUnit_Framework_TestResult->run() /*path_to_project*/vendor/phpunit/phpunit/src/Framework/TestCase.php:708
> PHP   9. PHPUnit_Framework_TestResult->endTest() /*path_to_project*/vendor/phpunit/phpunit/src/Framework/TestResult.php:750
> PHP  10. PHPUnit_TextUI_ResultPrinter->endTest() /*path_to_project*/vendor/phpunit/phpunit/src/Framework/TestResult.php:345
> PHP  11. PHPUnit_TextUI_ResultPrinter->writeProgress() /*path_to_project*/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:516
> PHP  12. str_repeat() /*path_to_project*/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:547
>  1 / 1 (100%)
> 
> Time: 100 ms, Memory: 6.00Mb
> 
> OK (1 test, 1 assertion)

I read the offending line in ResultPrinter.php and with some logging (thank God PHP is interpreted) I found that the Console helper class used by PHPUnit does not detect the number of columns available in the emacs buffer and uses 0 instead, causing later another variable to be negative, so invalid, and triggering this warning.

The pull request essentially prepends "stty cols (frame-width)" to the compile command (so it would be "stty cols (frame-width); phpunit -c ... --filter ..."), and in my setup it seems to work alright. I don't know if this will yield a good result when having the window split horizontally, but at least it won't trigger the warning.