### PR TITLE
Minor mode + Helm integration

### DIFF
--- a/phpunit-mode.el
+++ b/phpunit-mode.el
@@ -1,0 +1,21 @@
+;;; phpunit-mode.el --- Minor mode for PHPUnit
+
+(require 'phpunit)
+
+(defvar phpunit-mode-map
+  (let ((map (make-keymap)))
+    (define-key map (kbd "C-t f") 'phpunit-helm-function-tests)
+    (define-key map (kbd "C-t t") 'phpunit-current-test)
+    (define-key map (kbd "C-t c") 'phpunit-current-class)
+    (define-key map (kbd "C-t p") 'phpunit-current-project)
+    map)
+  "Keymap for PHPUnit minor mode")
+
+(define-minor-mode phpunit-mode
+  "PHPUnit minor mode"
+  :lighter " phpunit"
+  :keymap phpunit-mode-map)
+
+(add-to-list 'auto-mode-alist '("\\.php$'" . phpunit-mode))
+
+;;; phpunit-mode.el ends here

--- a/phpunit.el
+++ b/phpunit.el
@@ -113,7 +113,7 @@
     map)
   "Keymap for PHPUnit minor mode.")
 
-(add-to-list 'auto-mode-alist '("*\\.php\\'" . phpunit))
+(add-to-list 'auto-mode-alist '("\\.php\\'" . phpunit))
 
 (define-minor-mode phpunit
   "PHPUnit minor mode"
@@ -167,26 +167,26 @@
       (match-string-no-properties 1))))
 
 (defun phpunit-helm-get-all-test-candidates ()
-  ""
-  (let ((test-functions '()))
-    (save-excursion
-      (beginning-of-buffer)
-      (while (search-forward-regexp php-beginning-of-defun-regexp nil t)
-	(add-to-list 'test-functions (format "%S" (match-string-no-properties 1)))))
-    (message "test-functions found ZOMG: %s" test-functions)
-    test-functions))
+  "Populates Helm with a list of test functions within a class/file."
+  (with-helm-current-buffer
+    (let ((test-functions '()))
+      (save-excursion
+	(beginning-of-buffer)
+	(while (search-forward-regexp php-beginning-of-defun-regexp nil t)
+	  (add-to-list 'test-functions (match-string-no-properties 1))))
+      test-functions)))
 
-(defvar phpunit-helm-select-test-source
+(setq phpunit-helm-select-test-source
   '((name . "PHPUnit Tests")
     (candidates . phpunit-helm-get-all-test-candidates)
     (action . (lambda (test)
-		(message "Test: %s" test)))))
+		(phpunit-selected-test test)))))
 
 (defun phpunit-helm-select-test ()
   "Use Helm to select which test should be ran."
   (interactive)
   (require 'helm)
-  (helm :sources 'phpunit-helm-select-test-source
+  (helm :sources '(phpunit-helm-select-test-source)
 	:buffer "*phpunit-function-tests*"))
 
 (defun phpunit-arguments (args)

--- a/phpunit.el
+++ b/phpunit.el
@@ -7,7 +7,7 @@
 ;; Version: 0.7.0
 ;; Keywords: php, tests, phpunit
 
-;; Package-Requires: ((s "1.9.0") (f "0.16.0") (pkg-info "0.5") (Emacs "24") (helm "0.0.0"))
+;; Package-Requires: ((s "1.9.0") (f "0.16.0") (pkg-info "0.5") (Emacs "24"))
 
 ;;; License:
 
@@ -32,7 +32,7 @@
 
 ;; Thanks to tox.el(https://github.com/chmouel/tox.el) from Chmouel Boudjnah.
 
-;; To use this code, bind the functions `phpunit-current-test', `phpunit-current-class', `php-helm-select-test`
+;; To use this code, bind the functions `phpunit-current-test', `phpunit-current-class',
 ;; and `phpunit-current-project' to convenient keys with something like :
 
 ;; (define-key web-mode-map (kbd "C-x t") 'phpunit-current-test)
@@ -147,29 +147,6 @@
     (when (re-search-backward php-beginning-of-defun-regexp nil t)
       (match-string-no-properties 1))))
 
-(defun phpunit-helm-get-all-test-candidates ()
-  "Populates Helm with a list of test functions within a class/file."
-  (with-helm-current-buffer
-    (let ((test-functions '()))
-      (save-excursion
-	(beginning-of-buffer)
-	(while (search-forward-regexp php-beginning-of-defun-regexp nil t)
-	  (add-to-list 'test-functions (match-string-no-properties 1))))
-      test-functions)))
-
-(setq phpunit-helm-select-test-source
-  '((name . "PHPUnit Tests")
-    (candidates . phpunit-helm-get-all-test-candidates)
-    (action . (lambda (test)
-		(phpunit-selected-test test)))))
-
-(defun phpunit-helm-select-test ()
-  "Use Helm to select which test should be ran."
-  (interactive)
-  (require 'helm)
-  (helm :sources '(phpunit-helm-select-test-source)
-	:buffer "*phpunit-function-tests*"))
-
 (defun phpunit-arguments (args)
   (let ((opts args))
      (when phpunit-stop-on-error
@@ -194,13 +171,6 @@
 
 ;; API
 ;; ----
-
-;;;###autoload
-(defun phpunit-selected-test (test-function)
-  "Launch PHPUnit on selected test (Helm)."
-  (interactive)
-  (let ((args (s-concat " --filter '" (phpunit-get-current-class) "::" test-function "'")))
-    (phpunit-run args)))
 
 ;;;###autoload
 (defun phpunit-current-test ()

--- a/phpunit.el
+++ b/phpunit.el
@@ -32,7 +32,7 @@
 
 ;; Thanks to tox.el(https://github.com/chmouel/tox.el) from Chmouel Boudjnah.
 
-;; To use this code, bind the functions `phpunit-current-test', `phpunit-current-class'
+;; To use this code, bind the functions `phpunit-current-test', `phpunit-current-class', `php-helm-select-test`
 ;; and `phpunit-current-project' to convenient keys with something like :
 
 ;; (define-key web-mode-map (kbd "C-x t") 'phpunit-current-test)

--- a/phpunit.el
+++ b/phpunit.el
@@ -101,25 +101,6 @@
             (interactive)
             (add-to-list 'compilation-error-regexp-alist '("^\\(.+\\.php\\):\\([0-9]+\\)$" 1 2))))
 
-;; Minor mode setup/configuration
-;; ------------
-
-(defvar phpunit-map
-  (let ((map (make-keymap)))
-    (define-key map (kbd "C-t f") 'phpunit-helm-function-tests)
-    (define-key map (kbd "C-t t") 'phpunit-current-test)
-    (define-key map (kbd "C-t c") 'phpunit-current-class)
-    (define-key map (kbd "C-t p") 'phpunit-current-project)
-    map)
-  "Keymap for PHPUnit minor mode.")
-
-(add-to-list 'auto-mode-alist '("\\.php\\'" . phpunit))
-
-(define-minor-mode phpunit
-  "PHPUnit minor mode"
-  :lighter " phpunit"
-  :keymap phpunit-map)
-
 ;; Commands
 ;; -----------
 

--- a/phpunit.el
+++ b/phpunit.el
@@ -7,7 +7,7 @@
 ;; Version: 0.7.0
 ;; Keywords: php, tests, phpunit
 
-;; Package-Requires: ((s "1.9.0") (f "0.16.0") (pkg-info "0.5") (Emacs "24"))
+;; Package-Requires: ((s "1.9.0") (f "0.16.0") (pkg-info "0.5") (Emacs "24") (helm "0.0.0"))
 
 ;;; License:
 


### PR DESCRIPTION
I can separate this out if desired.

This brings in putting this library as a minor mode for all PHP files (there's no precise way to specify only test files unless we assume the suffix "Test.php" is the only test file).

I also added in Helm integration.  What this does is allow the user to select which test to run via using Helm and already-existing functions more or less.