### PR TITLE
Fix for Emacs 25.1-rc1

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -119,6 +119,9 @@
     ;;               "vendor/bin/phpunit"))
     (unless phpunit-executable
       (setq phpunit-executable phpunit-program))
+    (when (file-remote-p phpunit-executable)
+      (setq phpunit-executable
+            (tramp-file-name-localname (tramp-dissect-file-name phpunit-executable))))
     (s-concat phpunit-executable
               (if phpunit-configuration-file
                   (s-concat " -c " phpunit-configuration-file)


### PR DESCRIPTION
Not work in Emacs 25.1-rc1.

in tramp:

```el
(locate-dominating-file "" "vendor"))
;; 24.5.1   => "./"
;; 25.1-rc1 => "/scp:remote-server:/home/tadsan/project/"
```

This might a bug from TRAMP, but it is resolved by this patch.