### PR TITLE
Simplify phpunit-current-class

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -206,9 +206,7 @@
 (defun phpunit-current-class ()
   "Launch PHPUnit on current class."
   (interactive)
-  (let ((args (s-concat " --filter '(?<!" php-labelchar-regexp ")" (phpunit-get-current-class) "'")))
-    (phpunit-run args)))
-
+  (phpunit-run (s-chop-prefix (phpunit-get-root-directory) buffer-file-name)))
 
 ;;;###autoload
 (defun phpunit-current-project ()


### PR DESCRIPTION
In many cases it is better.  But when a file has multi class, compatibility will be broken.

Or should I divide it to another function? (for example `phpunit-current-test-file`)