### PR TITLE
Modify phpunit command priority

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -122,11 +122,12 @@
   "Return the command to launch unit test.
 `ARGS' corresponds to phpunit command line arguments."
   (let ((phpunit-executable nil)
-        (filename (or (buffer-file-name) "")))
+        (filename (or (buffer-file-name) ""))
+        (vendor-dir (locate-dominating-file "" "vendor")))
     (setq phpunit-executable
-          (or (executable-find "phpunit")
-              (concat (locate-dominating-file "" "vendor")
-                  "vendor/bin/phpunit")))
+          (if (and vendor-dir (file-exists-p (concat vendor-dir "vendor/bin/phpunit")))
+              (concat vendor-dir "vendor/bin/phpunit")
+            (executable-find "phpunit")))
     ;; (setq phpunit-executable
     ;;       (concat (locate-dominating-file filename "vendor")
     ;;               "vendor/bin/phpunit"))


### PR DESCRIPTION
In the current implementation, global installed PHPUnit takes precedence.

## Motivation

If the project has a PHPUnit in its dependencies, it is better to give priority to it will work well.

If you have projects you are currently working as a dependent package of global, the test will have that you do not operate to imagine. *(I just come back from hell...)*