### PR TITLE
Support custom phpunit command

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -54,14 +54,17 @@
   :group 'tools
   :group 'php)
 
-(defcustom phpunit-program "phpunit"
+(defcustom phpunit-program nil
   "PHPUnit binary path."
-  :type '(choice (file   :tag "Path to PHPUnit executable file.")
-                 (string :tag "PHPUnit command name. (require command in PATH)")))
+  :type '(choice (file     :tag "Path to PHPUnit executable file.")
+                 (function :tag "A function return PHPUnit executable file path.")
+                 (string   :tag "PHPUnit command name. (require command in PATH)")))
 
-(defcustom phpunit-arg ""
+(defcustom phpunit-arg nil
   "Argument to pass to phpunit."
-  :type 'string)
+  :type '(choice string
+                 (repeat string))
+  :group 'phpunit)
 
 (defcustom phpunit-stop-on-error nil
   "Stop execution upon first error."

--- a/phpunit.el
+++ b/phpunit.el
@@ -133,20 +133,21 @@
         (filename (or (buffer-file-name) ""))
         (vendor-dir (locate-dominating-file "" "vendor")))
     (setq phpunit-executable
-          (if (and vendor-dir (file-exists-p (concat vendor-dir "vendor/bin/phpunit")))
-              (concat vendor-dir "vendor/bin/phpunit")
-            (executable-find "phpunit")))
-    ;; (setq phpunit-executable
-    ;;       (concat (locate-dominating-file filename "vendor")
-    ;;               "vendor/bin/phpunit"))
+          (cond ((stringp phpunit-program) phpunit-program)
+                ((functionp phpunit-program) (funcall phpunit-program))
+                ((and vendor-dir (file-exists-p (concat vendor-dir "vendor/bin/phpunit")))
+                 (concat vendor-dir "vendor/bin/phpunit"))))
     (unless phpunit-executable
-      (setq phpunit-executable phpunit-program))
+      (setq phpunit-executable "phpunit"))
     (when (file-remote-p phpunit-executable)
       (setq phpunit-executable
             (tramp-file-name-localname (tramp-dissect-file-name phpunit-executable))))
     (s-concat phpunit-executable
+              (when phpunit-arg
+                (s-concat " " (if (stringp phpunit-arg) phpunit-arg
+                                (s-join " " (mapcar 'shell-quote-argument phpunit-arg)))))
               (if phpunit-configuration-file
-                  (s-concat " -c " phpunit-configuration-file)
+                  (s-concat " -c " (shell-quote-argument phpunit-configuration-file))
                 "")
               " "
               args)))


### PR DESCRIPTION
ref #38 
## Usage

``` el
(setq-local phpunit-program "docker")
(setq-local phpunit-arg '("exec" "-it" "container" "phpunit")
;; or (setq-local phpunit-arg "exec -it container phpunit")
```
