### PR TITLE
Add path to current test file for phpunit-current-test

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -250,7 +250,9 @@ https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.anno
   (let ((args (s-concat " --filter '"
 			(phpunit-get-current-class)
 			"::"
-			(phpunit-get-current-test) "'")))
+			(phpunit-get-current-test) "'"
+                        " "
+                        (s-chop-prefix (phpunit-get-root-directory) buffer-file-name))))
     (phpunit-run args)))
 
 


### PR DESCRIPTION
This change increases performance for `phpunit-current-test`.
Without the file path, the phpunit command relies solely on the
`--filter` flag to locate the test to run and takes ~3x longer
to start the test in a large PHP project.

Note: this changes the behavior of `php-current-test` in edge cases. When it cannot find a current test, it will now run the tests for the file, whereas before it would run _all_ tests from the root directory. 