### PR TITLE
Fix warnings

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -42,6 +42,8 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'compile)
+(require 'tramp)
 (require 's)
 (require 'f)
 (eval-when-compile

--- a/phpunit.el
+++ b/phpunit.el
@@ -214,7 +214,7 @@ https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.anno
       (goto-char (point-min))
       (search-forward "Available test group")
       (move-beginning-of-line 1)
-      (next-line)
+      (forward-line)
       (cl-loop
        for line in (s-split "\n" (buffer-substring-no-properties (point) (point-max)))
        if (s-starts-with? " - " line)


### PR DESCRIPTION
```
% make test

In phpunit--listing-groups:
phpunit.el:214:8:Warning: ‘next-line’ is for interactive use only; use
    ‘forward-line’ instead.

In phpunit--colorize-compilation-buffer:
phpunit.el:257:33:Warning: reference to free variable
    ‘compilation-filter-start’

In phpunit-run:
phpunit.el:277:17:Warning: reference to free variable
    ‘compilation-error-regexp-alist’
phpunit.el:277:17:Warning: assignment to free variable
    ‘compilation-error-regexp-alist’

In end of data:
phpunit.el:348:1:Warning: the following functions are not known to be defined:
    tramp-file-name-localname, tramp-dissect-file-name,
    ansi-color-apply-on-region
```