### PR TITLE
Feature/fix for spaces in project path

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -175,7 +175,7 @@
     (when (file-remote-p default-directory)
       (setq executable
             (tramp-file-name-localname (tramp-dissect-file-name executable))))
-    (s-concat executable
+    (s-concat (shell-quote-argument executable)
               (when phpunit-args
                 (s-concat " " (if (stringp phpunit-args) phpunit-args
                                 (s-join " " (mapcar 'shell-quote-argument phpunit-args)))))


### PR DESCRIPTION
I keep all my projects in a "Source Files" directory. When trying to execute phpunit on a test, it barks at me that the the "Source" directory is not found.  It doesn't appear to like the space in the file path.

I've updated the code to escape the executable path, which fixes the problem for me.

I do a lot more php than lisp, so please let me know if you think that there's a better way to do this!

Thanks!
--jfl