### PR TITLE
Expand path to PHPUnit execubatle file

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -163,7 +163,7 @@
           ((functionp executable) (funcall executable))
           ((and directory
                 (file-exists-p (concat directory "vendor/bin/phpunit")))
-           (concat directory "vendor/bin/phpunit"))
+           (expand-file-name (concat directory "vendor/bin/phpunit")))
           ((executable-find "phpunit") "phpunit")
           (t (error "PHPUnit command/package is not installed")))))
 


### PR DESCRIPTION
This problem is made by #58.
That occurs because "~" is escaped before being passed to the shell.