### PR TITLE
feat: Rerun last test (close #66)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # phpunit.el ChangeLog
 
+## Unreleased
+
+- fix: Improve handling of `hide-compilation-buffer`
+- feat: Rerun the most recently run test
+
 ## Version 0.17.1 (12/08/2018)
 
 - [#60](https://github.com/nlamirault/phpunit.el/pull/60): Hotfix: Path to `phpunit` could not be expanded

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These functions are available :
 * `phpunit-current-test`: launch unit tests for the current test in a class
 * `phpunit-current-class`: launch unit tests for the current class
 * `phpunit-current-project`: launch all unit tests
+* `phpunit-rerun`: re-launch the most recently launched unit tests 
 * `phpunit-group`: launch PHPUnit for group
 
 You can create some key bindings with these commands:
@@ -34,6 +35,7 @@ You can create some key bindings with these commands:
 (define-key web-mode-map (kbd "C-t t") 'phpunit-current-test)
 (define-key web-mode-map (kbd "C-t c") 'phpunit-current-class)
 (define-key web-mode-map (kbd "C-t p") 'phpunit-current-project)
+(define-key web-mode-map (kbd "C-t r") 'phpunit-rerun)
 ```
 
 or use the minor mode :

--- a/phpunit-mode.el
+++ b/phpunit-mode.el
@@ -28,6 +28,7 @@
     (define-key map (kbd "C-t t") 'phpunit-current-test)
     (define-key map (kbd "C-t c") 'phpunit-current-class)
     (define-key map (kbd "C-t p") 'phpunit-current-project)
+    (define-key map (kbd "C-t r") 'phpunit-rerun)
     map)
   "Keymap for PHPUnit minor mode.")
 

--- a/phpunit.el
+++ b/phpunit.el
@@ -289,10 +289,12 @@ https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.anno
   (let ((default-directory (phpunit-get-root-directory)))
     (shell-command-to-string (phpunit-get-program (phpunit-arguments args)))))
 
-(defun phpunit-run (args)
-  "Execute phpunit command with `ARGS'."
+(defun phpunit-run (args &optional dir)
+  "Execute phpunit command with `ARGS' in `DIR'.
+
+If `DIR' is not provided, it will be inferred with phpunit-get-root-directory."
   (add-to-list 'compilation-error-regexp-alist '("^\\(.+\\.php\\):\\([0-9]+\\)$" 1 2))
-  (let ((default-directory (phpunit-get-root-directory))
+  (let ((default-directory (or dir (phpunit-get-root-directory)))
         (compilation-process-setup-function #'phpunit--setup-compilation-buffer))
     (compile (phpunit-get-compile-command args))))
 
@@ -348,7 +350,7 @@ The STATUS describes how the compilation process finished."
                          (phpunit-get-current-test) "'"
                          " "
                          (s-chop-prefix (phpunit-get-root-directory) buffer-file-name)))
-         (cmd (apply-partially #'phpunit-run args)))
+         (cmd (apply-partially #'phpunit-run args (phpunit-get-root-directory))))
     (fset #'phpunit--run-last cmd)
     (funcall cmd)))
 
@@ -356,7 +358,7 @@ The STATUS describes how the compilation process finished."
 (defun phpunit-current-class ()
   "Launch PHPUnit on current class."
   (interactive)
-  (let ((cmd (apply-partially #'phpunit-run (s-chop-prefix (phpunit-get-root-directory t) buffer-file-name))))
+  (let ((cmd (apply-partially #'phpunit-run (s-chop-prefix (phpunit-get-root-directory t) buffer-file-name) (phpunit-get-root-directory))))
     (fset #'phpunit--run-last cmd)
     (funcall cmd)))
 
@@ -364,7 +366,7 @@ The STATUS describes how the compilation process finished."
 (defun phpunit-current-project ()
   "Launch PHPUnit on current project."
   (interactive)
-  (let ((cmd (apply-partially #'phpunit-run "")))
+  (let ((cmd (apply-partially #'phpunit-run "" (phpunit-get-root-directory))))
     (fset #'phpunit--run-last cmd)
     (funcall cmd)))
 


### PR DESCRIPTION
Hi! Fair warning: this my first elisp PR, so I'm *sure* I'm doing some things not quite right. *Any and all* tips and pointers are welcome!

This implements a "rerun last test" feature for all supported test commands. It does so by saving a partially applied closure over each actual test command. As an alternative, this could probably also be implemented by just saving the applicable dir and args as global vars and using those to rerun the last test. I found this approach pretty simple to achieve, and it needed less global state.

I have been using this code on and off again for several years and found it to work well. That said, the second commit is fairly new b/c I had some issues while recently working on interdependent code and tests in different projects. That change has been working well for several days, but is still relatively new.