### PR TITLE
feat: Support Laravel stack trace format

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -292,6 +292,8 @@ https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.anno
 (defun phpunit-run (args)
   "Execute phpunit command with `ARGS'."
   (add-to-list 'compilation-error-regexp-alist '("^\\(.+\\.php\\):\\([0-9]+\\)$" 1 2))
+  ;; format: #0 /path/to/file(line): class::method(param)
+  (add-to-list 'compilation-error-regexp-alist '("^#[0-9]+ \\(.+\\.php\\)(\\([0-9]+\\)):" 1 2))
   (let ((default-directory (phpunit-get-root-directory))
         (compilation-process-setup-function #'phpunit--setup-compilation-buffer))
     (compile (phpunit-get-compile-command args))))


### PR DESCRIPTION
As is, files printed in the compilation buffer are clickable if they match the `<file>:<line>` format. With Laravel feature tests, it seems that they also print stack traces that look like this:

```
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

.F

Time: 00:00.655, Memory: 44.50 MB

There was 1 failure:

1) Tests\Feature\CollateOrderControllerTest::can_post_new_order_in_seeds
Expected response status code [>=200, <300] but received 500.

The following exception occurred during the request:

ValueError: The items returned by the App\Adapters\PaperOrderAdapter do not include a `branch` element. in /Users/crcarter/src/Fedco/monorepo/sdk/src/Factories/OrderItemFactory.php:120
Stack trace:
#0 /Users/crcarter/src/Fedco/monorepo/sdk/src/Factories/OrderItemFactory.php(85): SDK\Factories\OrderItemFactory::validateAdapterItems(Object(App\Adapters\PaperOrderAdapter), Object(Illuminate\Support\Collection))
#1 /Users/crcarter/src/Fedco/monorepo/landscape/app/Factories/OrderFactory.php(25): SDK\Factories\OrderItemFactory::fromAdapter(Object(App\Adapters\PaperOrderAdapter))
#2 /Users/crcarter/src/Fedco/monorepo/landscape/app/Http/Controllers/CollateOrderController.php(42): App\Factories\OrderFactory::fromAdapter(Object(App\Adapters\PaperOrderAdapter))
...
```

This commit add a regex that will make such stack traces clickable as well.