### PR TITLE
 Prefer composer.json vs .git for phpunit/composer root folder location

### DIFF
--- a/phpunit.el
+++ b/phpunit.el
@@ -202,7 +202,7 @@
          (phpunit-configuration-file
           (file-truename (locate-dominating-file filename phpunit-configuration-file)))
          (:else
-          (cl-loop for file in '("phpunit.xml" "phpunit.xml.dist" ".git" "composer.json")
+          (cl-loop for file in '("phpunit.xml" "phpunit.xml.dist" "composer.json" ".git")
                    do (setq path (locate-dominating-file filename file))
                    if path return (file-truename path)
                    finally return (file-truename "./")))))))


### PR DESCRIPTION
In cases where more than one php project folders exist in a single git tree, prefer the composer.json file over the .git folder for project folder location.
I do not believe this will have negative impacts when there is more than one git tree inside a single php project folder (the reversed situation).